### PR TITLE
assert by msg type bug fix

### DIFF
--- a/features/inspect_all.feature
+++ b/features/inspect_all.feature
@@ -12,7 +12,7 @@ Scenario Outline: Basic TestRequest
   When "<sender>" sends a TestRequest with TestReqID "<req>"
   And I sleep 5 seconds
   Then "<receiver>" should receive a TestRequest with TestReqID "<req>"
-  And "<sender>" should receive a HeartBeat with TestReqID "<req>"
+  And "<sender>" should receive a Heartbeat with TestReqID "<req>"
 
   When I send the following FIX message from agent "<sender>": 
   """
@@ -39,7 +39,7 @@ Scenario Outline: Basic TestRequest
   When "<sender>" sends a TestRequest with TestReqID "<req>"
   And I sleep 5 seconds
   Then "<receiver>" should receive a TestRequest with TestReqID "<req>"
-  And "<sender>" should receive a HeartBeat with TestReqID "<req>"
+  And "<sender>" should receive a Heartbeat with TestReqID "<req>"
 
   When I send the following FIX message from agent "<sender>": 
   """

--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -23,7 +23,7 @@ When(/^"(.*?)" sends a TestRequest with TestReqID "(.*)"$/) do |agent, value|
   AgentFIX.agents_hash[agent.to_sym].sendToTarget(msg)
 end
 
-Then(/^"(.*?)" should receive a (TestRequest|HeartBeat) with TestReqID "(.*?)"$/) do |agent, messageType, value|
+Then(/^"(.*?)" should receive a (TestRequest|Heartbeat) with TestReqID "(.*?)"$/) do |agent, messageType, value|
   steps %Q{Then I should receive a FIX message of type "#{messageType}" with agent "#{agent}"}
 
   reqID = quickfix.field.TestReqID.new

--- a/lib/agent_fix/cucumber.rb
+++ b/lib/agent_fix/cucumber.rb
@@ -56,13 +56,18 @@ Then(/^I should receive (exactly )?(\d+)(?: FIX|fix)? messages(?: (?:on|over) FI
     
     scope=messages.slice(0, count)
 
+    msgType = nil
     unless type.nil?
-      unless FIXSpec::data_dictionary.nil?
-        type = FIXSpec::data_dictionary.get_msg_type(type)
+      unless FIXSpec::session_data_dictionary.nil?
+        msgType = FIXSpec::session_data_dictionary.get_msg_type(type)
+      end
+
+      if msgType.nil? && !FIXSpec::application_data_dictionary.nil?
+        msgType = FIXSpec::application_data_dictionary.get_msg_type(type)
       end
 
       scope.each do |msg|
-        expect(msg[:message].header.get_string(35)).to eq(type)
+        expect(msg[:message].header.get_string(35)).to eq(msgType)
       end
     end
   end


### PR DESCRIPTION
A few bug fixes here that were somewhat chained together:

We were doing an assignment on a variable defined outside the scope of an `anticipate` loop, but using that variable as an argument to the assigning function. So when the anticipate loop failed, the execution path differed on the retry. A simplified example:

```ruby
type = "Heartbeat"
anticipate do
  unless type.nil?
     type = data_dictionary.get_msg_type(type)
  end
  # use 'type' and fail somewhere...
end
```

Here `get_msg_type("Hearbeat")` will return `"0"`, but next time around, `get_msg_type("0")` will return `nil`. Which is not intended

Fixing this broke some existing tests, exposing the following other bugs:

- The cucumber tests were looking for "HeartBeat" in the data dictionary. The msgType in the DD is actually "Heartbeat".
- The function to `get_msg_type` was only being applied on the `FIXSpec::data_dictionary` (aliases with `FIXSpec::application_data_dictionary`). FIX50 admin messages weren't being looked up on the `FIXSpec::session_data_dictionary`